### PR TITLE
Copy readme - avoid copy with no sourcefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN npm install -g http-server
 WORKDIR /app
 
 # copy both 'package.json' and 'package-lock.json' (if available)
-COPY package*.json ./
+COPY README.md package*.json ./
 
 # install project dependencies
 RUN npm install


### PR DESCRIPTION
To avoid error 'COPY failed: no source files were specified'